### PR TITLE
Fix PHP8.1 deprecation + returned type ZEND_RESULT_CODE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 *.la
 *.lo
 *.loT
-.deps
+*.deps
+*.dep
 Makefile
 Makefile.fragments
 Makefile.global
@@ -35,3 +36,6 @@ run-tests.php
 
 .libs/
 __pycache__/
+.idea
+
+*~

--- a/php-closure.cpp
+++ b/php-closure.cpp
@@ -9,7 +9,7 @@ using namespace php_git2;
 
 // Custom class handlers
 
-static int closure_get_closure(
+static ZEND_RESULT_CODE closure_get_closure(
     zend_object* obj,
     zend_class_entry** ce_ptr,
     zend_function** fptr_ptr,
@@ -61,7 +61,7 @@ php_closure_object::~php_closure_object()
 
 // Implementation of custom class handlers
 
-int closure_get_closure(
+ZEND_RESULT_CODE closure_get_closure(
     zend_object* obj,
     zend_class_entry** ce_ptr,
     zend_function** fptr_ptr,

--- a/php-closure.cpp
+++ b/php-closure.cpp
@@ -9,12 +9,21 @@ using namespace php_git2;
 
 // Custom class handlers
 
-static ZEND_RESULT_CODE closure_get_closure(
+#if PHP_API_VERSION >= 20220829
+static zend_result closure_get_closure(
     zend_object* obj,
     zend_class_entry** ce_ptr,
     zend_function** fptr_ptr,
     zend_object** obj_ptr,
     zend_bool check_only);
+#else
+static int closure_get_closure(
+    zend_object* obj,
+    zend_class_entry** ce_ptr,
+    zend_function** fptr_ptr,
+    zend_object** obj_ptr,
+    zend_bool check_only);
+#endif
 
 // Class method entries
 
@@ -61,12 +70,21 @@ php_closure_object::~php_closure_object()
 
 // Implementation of custom class handlers
 
-ZEND_RESULT_CODE closure_get_closure(
+#if PHP_API_VERSION >= 20220829
+zend_result closure_get_closure(
     zend_object* obj,
     zend_class_entry** ce_ptr,
     zend_function** fptr_ptr,
     zend_object** obj_ptr,
     zend_bool check_only)
+#else
+int closure_get_closure(
+    zend_object* obj,
+    zend_class_entry** ce_ptr,
+    zend_function** fptr_ptr,
+    zend_object** obj_ptr,
+    zend_bool check_only)
+#endif
 {
     php_closure_object* closure;
     closure = php_zend_object<php_closure_object>::get_storage(obj);

--- a/php-git2.h
+++ b/php-git2.h
@@ -45,6 +45,39 @@ extern "C" {
 
 // Module globals
 
+
+#ifndef convert_to_explicit_type
+#define convert_to_explicit_type(pzv, type)		\
+	do {										\
+		switch (type) {							\
+			case IS_NULL:						\
+				convert_to_null(pzv);			\
+				break;							\
+			case IS_LONG:						\
+				convert_to_long(pzv);			\
+				break;							\
+			case IS_DOUBLE:						\
+				convert_to_double(pzv);			\
+				break;							\
+			case _IS_BOOL:						\
+				convert_to_boolean(pzv);		\
+				break;							\
+			case IS_ARRAY:						\
+				convert_to_array(pzv);			\
+				break;							\
+			case IS_OBJECT:						\
+				convert_to_object(pzv);			\
+				break;							\
+			case IS_STRING:						\
+				convert_to_string(pzv);			\
+				break;							\
+			default:							\
+				assert(0);						\
+				break;							\
+		}										\
+	} while (0);
+#endif
+
 ZEND_BEGIN_MODULE_GLOBALS(git2)
   bool propagateError;
   bool requestActive;

--- a/php-git2.h
+++ b/php-git2.h
@@ -43,41 +43,9 @@ extern "C" {
 #include <cstdio>
 #include <cstdarg>
 
+#include "php-shims.h"
+
 // Module globals
-
-
-#ifndef convert_to_explicit_type
-#define convert_to_explicit_type(pzv, type)		\
-	do {										\
-		switch (type) {							\
-			case IS_NULL:						\
-				convert_to_null(pzv);			\
-				break;							\
-			case IS_LONG:						\
-				convert_to_long(pzv);			\
-				break;							\
-			case IS_DOUBLE:						\
-				convert_to_double(pzv);			\
-				break;							\
-			case _IS_BOOL:						\
-				convert_to_boolean(pzv);		\
-				break;							\
-			case IS_ARRAY:						\
-				convert_to_array(pzv);			\
-				break;							\
-			case IS_OBJECT:						\
-				convert_to_object(pzv);			\
-				break;							\
-			case IS_STRING:						\
-				convert_to_string(pzv);			\
-				break;							\
-			default:							\
-				assert(0);						\
-				break;							\
-		}										\
-	} while (0);
-#endif
-
 ZEND_BEGIN_MODULE_GLOBALS(git2)
   bool propagateError;
   bool requestActive;

--- a/php-shims.h
+++ b/php-shims.h
@@ -1,0 +1,51 @@
+/*
+ * php-shims.h
+ *
+ * Copyright (C) Roger P. Gee
+ */
+
+#ifndef PHPGIT2_SHIMS_H
+#define PHPGIT2_SHIMS_H
+
+// Define convert_to_explicit_type if we are compiling for PHP > 8.0.
+#if PHP_API_VERSION > 20200930
+#define convert_to_explicit_type(pzv, type)		\
+	do {										\
+		switch (type) {							\
+			case IS_NULL:						\
+				convert_to_null(pzv);			\
+				break;							\
+			case IS_LONG:						\
+				convert_to_long(pzv);			\
+				break;							\
+			case IS_DOUBLE:						\
+				convert_to_double(pzv);			\
+				break;							\
+			case _IS_BOOL:						\
+				convert_to_boolean(pzv);		\
+				break;							\
+			case IS_ARRAY:						\
+				convert_to_array(pzv);			\
+				break;							\
+			case IS_OBJECT:						\
+				convert_to_object(pzv);			\
+				break;							\
+			case IS_STRING:						\
+				convert_to_string(pzv);			\
+				break;							\
+			default:							\
+				assert(0);						\
+				break;							\
+		}										\
+	} while (0);
+#endif
+
+#endif
+
+/*
+ * Local Variables:
+ * mode:c++
+ * indent-tabs-mode:nil
+ * tab-width:4
+ * End:
+ */


### PR DESCRIPTION
I have fixed some deprecations due to PHP8.1 (I am using PHP8.2)
So far, there is still an error that I couldn't figure out.

An input would be very welcome :)

```
./php-function.h:473:17: error: call to 'php_return' is ambiguous
                php_git2::php_return<ReturnPos>(retval,vars,return_value);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./blob.h:273:46: note: in instantiation of function template specialization 'zif_php_git2_function<php_git2::func_wrapper<unsigned long long, const git_blob *>::func<&git_blob_rawsize>, php_git2::local_pack<php_git2::php_resource<php_git2::git2_resource<git_blob>>>, 0, php_git2::sequence<0>, php_git2::sequence<0>>' requested here
static constexpr auto ZIF_GIT_BLOB_RAWSIZE = zif_php_git2_function<
                                             ^
./php-function.h:281:5: note: candidate function [with ReturnPos = 0, Ts = <php_git2::php_resource<php_git2::git2_resource<git_blob>>>]
    php_return(char retval,local_pack<Ts...>&,zval* return_value)
    ^
./php-function.h:289:5: note: candidate function [with ReturnPos = 0, Ts = <php_git2::php_resource<php_git2::git2_resource<git_blob>>>]
    php_return(zend_long retval,local_pack<Ts...>&,zval* return_value)
    ^
./php-function.h:296:5: note: candidate function [with ReturnPos = 0, Ts = <php_git2::php_resource<php_git2::git2_resource<git_blob>>>]
    php_return(int retval,local_pack<Ts...>&,zval* return_value)
    ^
./php-function.h:303:5: note: candidate function [with ReturnPos = 0, Ts = <php_git2::php_resource<php_git2::git2_resource<git_blob>>>]
    php_return(unsigned int retval,local_pack<Ts...>&,zval* return_value)
    ^
./php-function.h:310:5: note: candidate function [with ReturnPos = 0, Ts = <php_git2::php_resource<php_git2::git2_resource<git_blob>>>]
    php_return(size_t retval,local_pack<Ts...>&,zval* return_value)
```